### PR TITLE
Use APIGatewayProxyRequestEvent to get the input parameter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ lazy val root = (project in file("."))
       scalaCsv,
       typeSafeConfig,
       awsLambda,
+      awsLambdaJavaEvents,
       awsSsm,
       metadataValidation,
       generatedGraphql,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,7 @@ object Dependencies {
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.187"
   lazy val typeSafeConfig = "com.typesafe" % "config" % "1.4.3"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.3"
+  lazy val awsLambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.11.4"
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.23.17"
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % "0.1.105"
   lazy val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % log4CatsVersion

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -1,13 +1,13 @@
 package uk.gov.nationalarchives.draftmetadatavalidator
 
 import cats.effect.IO
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
 import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
 import graphql.codegen.GetDisplayProperties.displayProperties.DisplayProperties
 import graphql.codegen.GetDisplayProperties.{displayProperties => dp}
 import graphql.codegen.UpdateConsignmentStatus.{updateConsignmentStatus => ucs}
-import io.circe.generic.auto._
-import io.circe.parser.decode
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 import software.amazon.awssdk.http.apache.ApacheHttpClient
@@ -22,11 +22,9 @@ import uk.gov.nationalarchives.draftmetadatavalidator.Lambda.{DraftMetadata, get
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeployment}
 
-import java.io.{InputStream, OutputStream}
 import java.net.URI
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.io.Source
 
 class Lambda {
 
@@ -40,12 +38,13 @@ class Lambda {
   val updateConsignmentStatusClient = new GraphQLClient[ucs.Data, ucs.Variables](apiUrl)
   val graphQlApi: GraphQlApi = GraphQlApi(keycloakUtils, customMetadataClient, updateConsignmentStatusClient, displayPropertiesClient)
 
-  def handleRequest(input: InputStream, output: OutputStream): Unit = {
-    val body: String = Source.fromInputStream(input).mkString
+  def handleRequest(event: APIGatewayProxyRequestEvent, context: Context): Unit = {
+    val pathParam = event.getPathParameters
+
     val s3Files = S3Files(S3Utils(s3Async(s3Endpoint)))
 
     for {
-      draftMetadata <- IO.fromEither(decode[DraftMetadata](body))
+      draftMetadata <- IO(DraftMetadata(UUID.fromString(pathParam.get("consignmentId"))))
       _ <- s3Files.downloadFile(bucket, draftMetadata)
       hasErrors <- validateMetadata(draftMetadata)
       _ <- if (hasErrors) s3Files.uploadFile(bucket, draftMetadata) else IO.unit

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
@@ -1,17 +1,12 @@
 package uk.gov.nationalarchives.draftmetadatavalidator
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
+
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 object LambdaRunner extends App {
-  private val body =
-    """{
-      |  "consignmentId": "f82af3bf-b742-454c-9771-bfd6c5eae749"
-      |}
-      |""".stripMargin
-
-  private val baos = new ByteArrayInputStream(body.getBytes())
-  val output = new ByteArrayOutputStream()
-  new Lambda().handleRequest(baos, output)
-  val res = output.toByteArray.map(_.toChar).mkString
-  println(res)
+  val pathParams = Map("consignmentId" -> "f82af3bf-b742-454c-9771-bfd6c5eae749").asJava
+  val event = new APIGatewayProxyRequestEvent()
+  event.setPathParameters(pathParams)
+  new Lambda().handleRequest(event, null)
 }

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -1,15 +1,18 @@
 package uk.gov.nationalarchives.draftmetadatavalidator
 
+import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, urlEqualTo}
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
-import org.apache.commons.io.output.ByteArrayOutputStream
+import org.mockito.MockitoSugar.mock
 
-import java.io.ByteArrayInputStream
 import java.nio.file.{Files, Paths}
+import scala.jdk.CollectionConverters.MapHasAsJava
 
 class LambdaSpec extends ExternalServicesSpec {
 
   val consignmentId = "f82af3bf-b742-454c-9771-bfd6c5eae749"
+  val mockContext: Context = mock[Context]
 
   def mockS3Response(): StubMapping = {
     val fileId = "sample.csv"
@@ -21,19 +24,20 @@ class LambdaSpec extends ExternalServicesSpec {
     )
   }
 
-  def createEvent: ByteArrayInputStream = {
-    val input =
-      s"""{
-        |  "consignmentId": "$consignmentId"
-        |}""".stripMargin
-    new ByteArrayInputStream(input.getBytes())
+  def createEvent: APIGatewayProxyRequestEvent = {
+    val pathParams = Map("consignmentId" -> consignmentId).asJava
+    val event = new APIGatewayProxyRequestEvent()
+    event.setPathParameters(pathParams)
+    event
   }
 
   "handleRequest" should "download the draft metadata csv file, validate it and re-upload to s3 bucket if it has any errors" in {
     authOkJson()
     graphqlOkJson()
-    val outputStream = new ByteArrayOutputStream()
     mockS3Response()
-    new Lambda().handleRequest(createEvent, outputStream)
+    val pathParams = Map("consignmentId" -> consignmentId).asJava
+    val event = new APIGatewayProxyRequestEvent()
+    event.setPathParameters(pathParams)
+    new Lambda().handleRequest(createEvent, mockContext)
   }
 }


### PR DESCRIPTION
API Gateway sends a request with `APIGatewayProxyRequestEvent` only so I have to use it to get the `consignmentId`.