### PR TITLE
TDRD 88 - Enable draft metadata validator to be triggered from a step function

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 import Dependencies._
 
-ThisBuild / scalaVersion     := "2.13.10"
-ThisBuild / version          := "0.1.0-SNAPSHOT"
-ThisBuild / organization     := "uk.gov.nationalarchives"
+ThisBuild / scalaVersion := "2.13.10"
+ThisBuild / version := "0.1.0-SNAPSHOT"
+ThisBuild / organization := "uk.gov.nationalarchives"
 
 lazy val root = (project in file("."))
   .settings(
@@ -27,8 +27,8 @@ lazy val root = (project in file("."))
   )
 
 (assembly / assemblyMergeStrategy) := {
-  case PathList("META-INF", xs@_*) => MergeStrategy.discard
-  case _ => MergeStrategy.first
+  case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+  case _                             => MergeStrategy.first
 }
 
 (Test / fork) := true

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -64,8 +64,8 @@ class Lambda[Input] extends RequestHandler[Input, APIGatewayProxyResponseEvent] 
   private def extractConsignmentId(lambdaInput: Input): String = {
     lambdaInput match {
       case api: APIGatewayProxyRequestEvent => api.getPathParameters.get("consignmentId")
-      case json: Map[String, Any] => json("consignmentId").asInstanceOf[String]
-      case _ => throw new IllegalArgumentException("Unexpected lambda input type")
+      case json: Map[String, Any]           => json("consignmentId").asInstanceOf[String]
+      case _                                => throw new IllegalArgumentException("Unexpected lambda input type")
     }
   }
   private def validateMetadata(draftMetadata: DraftMetadata): IO[Boolean] = {

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -46,10 +46,11 @@ class Lambda extends RequestHandler[ConsignmentInput, APIGatewayProxyResponseEve
   private val addOrUpdateBulkFileMetadataClient = new GraphQLClient[afm.Data, afm.Variables](apiUrl)
   private val graphQlApi: GraphQlApi = GraphQlApi(keycloakUtils, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, displayPropertiesClient)
 
-  def handleRequest(input: ConsignmentInput, context: Context): APIGatewayProxyResponseEvent = {
+  def handleRequest(input: String, context: Context): APIGatewayProxyResponseEvent = {
+    println(s"Input: Input")
     val s3Files = S3Files(S3Utils(s3Async(s3Endpoint)))
     for {
-      draftMetadata <- IO(DraftMetadata(UUID.fromString(input.consignmentId)))
+      draftMetadata <- IO(DraftMetadata(UUID.fromString("03175df5-3f61-4036-af05-e2ad9ae6364d")))
       _ <- s3Files.downloadFile(bucket, draftMetadata)
       hasErrors <- validateMetadata(draftMetadata)
       _ <- if (hasErrors) s3Files.uploadFile(bucket, draftMetadata) else IO.unit

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -1,7 +1,7 @@
 package uk.gov.nationalarchives.draftmetadatavalidator
 
 import cats.effect.IO
-import com.amazonaws.services.lambda.runtime.Context
+import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
 import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
 import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
@@ -33,7 +33,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Lambda {
+class Lambda[Input] extends RequestHandler[Input, APIGatewayProxyResponseEvent] {
 
   implicit val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
   implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(authUrl, "tdr", timeToLiveSecs)
@@ -46,12 +46,11 @@ class Lambda {
   private val addOrUpdateBulkFileMetadataClient = new GraphQLClient[afm.Data, afm.Variables](apiUrl)
   private val graphQlApi: GraphQlApi = GraphQlApi(keycloakUtils, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, displayPropertiesClient)
 
-  def handleRequest(event: APIGatewayProxyRequestEvent, context: Context): APIGatewayProxyResponseEvent = {
-    val pathParam = event.getPathParameters
-
+  def handleRequest(input: Input, context: Context): APIGatewayProxyResponseEvent = {
+    val consignmentId = extractConsignmentId(input)
     val s3Files = S3Files(S3Utils(s3Async(s3Endpoint)))
     for {
-      draftMetadata <- IO(DraftMetadata(UUID.fromString(pathParam.get("consignmentId"))))
+      draftMetadata <- IO(DraftMetadata(UUID.fromString(consignmentId)))
       _ <- s3Files.downloadFile(bucket, draftMetadata)
       hasErrors <- validateMetadata(draftMetadata)
       _ <- if (hasErrors) s3Files.uploadFile(bucket, draftMetadata) else IO.unit
@@ -62,6 +61,13 @@ class Lambda {
     }
   }.unsafeRunSync()(cats.effect.unsafe.implicits.global)
 
+  private def extractConsignmentId(lambdaInput: Input): String = {
+    lambdaInput match {
+      case api: APIGatewayProxyRequestEvent => api.getPathParameters.get("consignmentId")
+      case json: Map[String, Any] => json("consignmentId").asInstanceOf[String]
+      case _ => throw new IllegalArgumentException("Unexpected lambda input type")
+    }
+  }
   private def validateMetadata(draftMetadata: DraftMetadata): IO[Boolean] = {
     val clientSecret = getClientSecret(clientSecretPath, endpoint)
     for {

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -33,7 +33,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Lambda extends RequestHandler[String, APIGatewayProxyResponseEvent] {
+class Lambda extends RequestHandler[java.util.Map[String, Object], APIGatewayProxyResponseEvent] {
 
   implicit val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
   implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(authUrl, "tdr", timeToLiveSecs)
@@ -46,8 +46,8 @@ class Lambda extends RequestHandler[String, APIGatewayProxyResponseEvent] {
   private val addOrUpdateBulkFileMetadataClient = new GraphQLClient[afm.Data, afm.Variables](apiUrl)
   private val graphQlApi: GraphQlApi = GraphQlApi(keycloakUtils, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, displayPropertiesClient)
 
-  def handleRequest(input: String, context: Context): APIGatewayProxyResponseEvent = {
-    println(s"Input: Input")
+  def handleRequest(input: java.util.Map[String, Object], context: Context): APIGatewayProxyResponseEvent = {
+    println(s"Input: $input")
     val s3Files = S3Files(S3Utils(s3Async(s3Endpoint)))
     for {
       draftMetadata <- IO(DraftMetadata(UUID.fromString("03175df5-3f61-4036-af05-e2ad9ae6364d")))

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -2,7 +2,7 @@ package uk.gov.nationalarchives.draftmetadatavalidator
 
 import cats.effect.IO
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
-import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyRequestEvent, APIGatewayProxyResponseEvent}
+import com.amazonaws.services.lambda.runtime.events.{APIGatewayProxyResponseEvent}
 import graphql.codegen.GetCustomMetadata.customMetadata.CustomMetadata
 import graphql.codegen.GetCustomMetadata.{customMetadata => cm}
 import graphql.codegen.GetDisplayProperties.displayProperties.DisplayProperties
@@ -163,5 +163,3 @@ object Lambda {
 
   def getFolderPath(draftMetadata: DraftMetadata) = s"""${rootDirectory}/${draftMetadata.consignmentId}"""
 }
-
-case class ConsignmentInput(consignmentId: String)

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -33,7 +33,7 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Lambda extends RequestHandler[ConsignmentInput, APIGatewayProxyResponseEvent] {
+class Lambda extends RequestHandler[String, APIGatewayProxyResponseEvent] {
 
   implicit val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
   implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(authUrl, "tdr", timeToLiveSecs)

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
@@ -5,8 +5,6 @@ import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 object LambdaRunner extends App {
-  val pathParams = Map("consignmentId" -> "f82af3bf-b742-454c-9771-bfd6c5eae749").asJava
-  val event = new APIGatewayProxyRequestEvent()
-  event.setPathParameters(pathParams)
-  // new Lambda().handleRequest(event, null)
+  val input = Map("consignmentId" -> "f82af3bf-b742-454c-9771-bfd6c5eae749".asInstanceOf[Object]).asJava
+  new Lambda().handleRequest(input, null)
 }

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
@@ -8,5 +8,5 @@ object LambdaRunner extends App {
   val pathParams = Map("consignmentId" -> "f82af3bf-b742-454c-9771-bfd6c5eae749").asJava
   val event = new APIGatewayProxyRequestEvent()
   event.setPathParameters(pathParams)
-  new Lambda().handleRequest(event, null)
+  // new Lambda().handleRequest(event, null)
 }

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -45,8 +45,8 @@ class LambdaSpec extends ExternalServicesSpec {
     val pathParams = Map("consignmentId" -> consignmentId).asJava
     val event = new APIGatewayProxyRequestEvent()
     event.setPathParameters(pathParams)
-    val response = new Lambda().handleRequest(createEvent, mockContext)
-    response.getStatusCode should equal(200)
+    //val response = new Lambda().handleRequest(createEvent, mockContext)
+    //response.getStatusCode should equal(200)
   }
 
   "handleRequest" should "download the draft metadata csv file, validate it and re-upload to s3 bucket if it has any errors" in {
@@ -57,7 +57,7 @@ class LambdaSpec extends ExternalServicesSpec {
     val pathParams = Map("consignmentId" -> consignmentId).asJava
     val event = new APIGatewayProxyRequestEvent()
     event.setPathParameters(pathParams)
-    val response = new Lambda().handleRequest(createEvent, mockContext)
-    response.getStatusCode should equal(200)
+    //val response = new Lambda().handleRequest(createEvent, mockContext)
+    //response.getStatusCode should equal(200)
   }
 }

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -12,7 +12,7 @@ import scala.jdk.CollectionConverters.MapHasAsJava
 
 class LambdaSpec extends ExternalServicesSpec {
 
-  val consignmentId = "f82af3bf-b742-454c-9771-bfd6c5eae749"
+  val consignmentId: Object = "f82af3bf-b742-454c-9771-bfd6c5eae749"
   val mockContext: Context = mock[Context]
 
   def mockS3GetResponse(fileName: String): StubMapping = {
@@ -31,22 +31,13 @@ class LambdaSpec extends ExternalServicesSpec {
     )
   }
 
-  def createEvent: APIGatewayProxyRequestEvent = {
-    val pathParams = Map("consignmentId" -> consignmentId).asJava
-    val event = new APIGatewayProxyRequestEvent()
-    event.setPathParameters(pathParams)
-    event
-  }
-
   "handleRequest" should "download the draft metadata csv file, validate and save to db if it has no errors" in {
     authOkJson()
     graphqlOkJson(true)
     mockS3GetResponse("sample.csv")
-    val pathParams = Map("consignmentId" -> consignmentId).asJava
-    val event = new APIGatewayProxyRequestEvent()
-    event.setPathParameters(pathParams)
-    //val response = new Lambda().handleRequest(createEvent, mockContext)
-    //response.getStatusCode should equal(200)
+    val input = Map("consignmentId" -> consignmentId).asJava
+    val response = new Lambda().handleRequest(input, mockContext)
+    response.getStatusCode should equal(200)
   }
 
   "handleRequest" should "download the draft metadata csv file, validate it and re-upload to s3 bucket if it has any errors" in {
@@ -54,10 +45,8 @@ class LambdaSpec extends ExternalServicesSpec {
     graphqlOkJson()
     mockS3GetResponse("invalid-sample.csv")
     mockS3PutResponse()
-    val pathParams = Map("consignmentId" -> consignmentId).asJava
-    val event = new APIGatewayProxyRequestEvent()
-    event.setPathParameters(pathParams)
-    //val response = new Lambda().handleRequest(createEvent, mockContext)
-    //response.getStatusCode should equal(200)
+    val input = Map("consignmentId" -> consignmentId).asJava
+    val response = new Lambda().handleRequest(input, mockContext)
+    response.getStatusCode should equal(200)
   }
 }


### PR DESCRIPTION
As step function inputs are custom defined, a lambda when called from a step function just receives a json blob.

We are evolving the draft metadata architecture for the validator to be called from a step function following other checks, with a single "consignmentId" parameter provided.

This adds extraction logic to enable this. It also keeps compatibility with the existing api proxy trigger for now by grabbing the consignmentId path parameter from the raw event json, but we will be able to remove this once the new step function trigger from the frontend is up and running.