### PR TITLE
Handle optional parameters

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaRunner.scala
@@ -1,7 +1,5 @@
 package uk.gov.nationalarchives.draftmetadatavalidator
 
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
-
 import scala.jdk.CollectionConverters.MapHasAsJava
 
 object LambdaRunner extends App {


### PR DESCRIPTION
To make the Lambda more configurable allow passing in of additional optional parameters

This will support different configurations, for example validation metadata in different source bucket, validating against different schemas etc