### PR TITLE
TDRD-551: title and desc must be open, not null, in an open record

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,9 +8,9 @@ object Dependencies {
 
   lazy val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "2.0.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
-  lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.78"
+  lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.81" exclude("uk.gov.nationalarchives","da-metadata-schema_3")
   lazy val schemaUtils = "uk.gov.nationalarchives" %% "tdr-schema-utils" % "0.0.78"
-  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.38"
+  lazy val metadataSchema = "uk.gov.nationalarchives" % "da-metadata-schema_3" % "0.0.40"
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.391"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.193"
   lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.219"

--- a/src/test/resources/sample.csv
+++ b/src/test/resources/sample.csv
@@ -1,4 +1,4 @@
 ﻿Filepath,Filename,Date last modified,Date of the record,Description,Former reference,Closure status,Closure Start Date,Closure Period,FOI exemption code,FOI decision asserted,Is the title sensitive for the public?,Add alternative title without the file extension,Is the description sensitive for the public?,Alternative description,Language,Translated title of record,UUID
-test/test3.txt,test3.txt,2024-03-26,,eee,,Open,,,,,,,,,English,,a060c57d-1639-4828-9a7a-67a7c64dbf6c
+test/test3.txt,test3.txt,2024-03-26,,eee,,Open,,,,,No,,No,,English,,a060c57d-1639-4828-9a7a-67a7c64dbf6c
 test/test1.txt,test1.txt,2024-03-26,,hello,,Closed,1990-01-01,33,27(1)|27(2),1990-01-01,Yes,title,No,,English,,cbf2cba5-f1dc-45bd-ae6d-2b042336ce6c
-test/test2.txt,test2.txt,2024-03-26,,www,,Open,,,,,,,,,English,,c4d5e0f1-f6e1-4a77-a7c0-a4317404da00
+test/test2.txt,test2.txt,2024-03-26,,www,,Open,,,,,No,,No,,English,,c4d5e0f1-f6e1-4a77-a7c0-a4317404da00

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -146,9 +146,9 @@ class LambdaSpec extends ExternalServicesSpec {
           AddOrUpdateMetadata("ClosurePeriod", ""),
           AddOrUpdateMetadata("FoiExemptionCode", ""),
           AddOrUpdateMetadata("FoiExemptionAsserted", ""),
-          AddOrUpdateMetadata("TitleClosed", ""),
+          AddOrUpdateMetadata("TitleClosed", "false"),
           AddOrUpdateMetadata("TitleAlternate", ""),
-          AddOrUpdateMetadata("DescriptionClosed", ""),
+          AddOrUpdateMetadata("DescriptionClosed", "false"),
           AddOrUpdateMetadata("DescriptionAlternate", ""),
           AddOrUpdateMetadata("Language", "English"),
           AddOrUpdateMetadata("file_name_translation", "")
@@ -185,9 +185,9 @@ class LambdaSpec extends ExternalServicesSpec {
           AddOrUpdateMetadata("ClosurePeriod", ""),
           AddOrUpdateMetadata("FoiExemptionCode", ""),
           AddOrUpdateMetadata("FoiExemptionAsserted", ""),
-          AddOrUpdateMetadata("TitleClosed", ""),
+          AddOrUpdateMetadata("TitleClosed", "false"),
           AddOrUpdateMetadata("TitleAlternate", ""),
-          AddOrUpdateMetadata("DescriptionClosed", ""),
+          AddOrUpdateMetadata("DescriptionClosed", "false"),
           AddOrUpdateMetadata("DescriptionAlternate", ""),
           AddOrUpdateMetadata("Language", "English"),
           AddOrUpdateMetadata("file_name_translation", "")


### PR DESCRIPTION
- title closed and description closed can never be null (must be open for an open record, must be boolean for a closed record)
- if we get an alternative title or  alternative description then the title or the description must be closed