### PR TITLE
Restore accidentally deleted test

### DIFF
--- a/src/test/resources/json/error-file.json
+++ b/src/test/resources/json/error-file.json
@@ -4,7 +4,7 @@
   "fileError" : "SCHEMA_VALIDATION",
   "validationErrors" : [
     {
-      "assetId" : "a060c57d-1639-4828-9a7a-67a7c64dbf6c",
+      "assetId" : "test/test3.txt",
       "errors" : [
         {
           "validationProcess" : "SCHEMA_CLOSURE_CLOSED",
@@ -65,13 +65,13 @@
       ]
     },
     {
-      "assetId" : "cbf2cba5-f1dc-45bd-ae6d-2b042336ce6c",
+      "assetId" : "test/test1.txt",
       "errors" : [
         {
           "validationProcess" : "SCHEMA_BASE",
           "property" : "FOI exemption code",
           "errorKey" : "enum",
-          "message" : "This must be a pipe delimited list of valid FOI codes, (eg. 31|33). Please see the guidance for more detail on valid codes"
+          "message" : "Must be a pipe delimited list of valid FOI codes, (eg. 31|33). Please see the guidance for more detail on valid codes"
         }
       ],
       "data" : [

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -97,6 +97,13 @@ class LambdaSpec extends ExternalServicesSpec {
     updateConsignmentStatusInput.statusValue must be(Some("Completed"))
   }
 
+  "handleRequest" should "download the draft metadata csv file, check for schema errors and save error file with errors to s3" in {
+    authOkJson()
+    graphqlOkJson()
+    mockS3GetResponse("invalid-sample.csv")
+    checkFileError("json/error-file.json")
+  }
+
   "handleRequest" should "download the draft metadata csv file, check for duplicate columns and save error file with errors to s3" in {
     authOkJson()
     graphqlOkJson()


### PR DESCRIPTION
It looks like one of our test error data sets was inadvertently removed from `LambdaSpec`'s cover and was overwritten by a new test. This restores it and brings the error file up to date.