### PR TITLE
TDRD-675 - Fix lambda not failing

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/GraphQlApi.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/GraphQlApi.scala
@@ -32,14 +32,18 @@ class GraphQlApi(
   def getCustomMetadata(consignmentId: UUID, clientSecret: String)(implicit executionContext: ExecutionContext): IO[List[cm.CustomMetadata]] = for {
     token <- keycloak.serviceAccountToken(clientId, clientSecret).toIO
     metadata <- customMetadataClient.getResult(token, cm.document, cm.Variables(consignmentId).some).toIO
-    data <- IO.fromOption(metadata.data)(new RuntimeException("No custom metadata definitions found"))
+    data <- IO.fromOption(metadata.data)(
+      new RuntimeException(metadata.errors.map(_.message).headOption.getOrElse("No custom metadata definitions found"))
+    )
   } yield data.customMetadata
 
   def updateConsignmentStatus(consignmentId: UUID, clientSecret: String, statusType: String, statusValue: String)(implicit executionContext: ExecutionContext): IO[Option[Int]] =
     for {
       token <- keycloak.serviceAccountToken(clientId, clientSecret).toIO
       metadata <- updateConsignmentStatus.getResult(token, ucs.document, ucs.Variables(ConsignmentStatusInput(consignmentId, statusType, statusValue.some)).some).toIO
-      data <- IO.fromOption(metadata.data)(new RuntimeException("Unable to update consignment status"))
+      data <- IO.fromOption(metadata.data)(
+        new RuntimeException(metadata.errors.map(_.message).headOption.getOrElse("Unable to update consignment status"))
+      )
     } yield data.updateConsignmentStatus
 
   def addOrUpdateBulkFileMetadata(consignmentId: UUID, clientSecret: String, fileMetadata: List[AddOrUpdateFileMetadata])(implicit
@@ -48,7 +52,9 @@ class GraphQlApi(
     for {
       token <- keycloak.serviceAccountToken(clientId, clientSecret).toIO
       metadata <- addOrUpdateBulkFileMetadata.getResult(token, afm.document, afm.Variables(AddOrUpdateBulkFileMetadataInput(consignmentId, fileMetadata)).some).toIO
-      data <- IO.fromOption(metadata.data)(new RuntimeException("Unable to add or update bulk file metadata"))
+      data <- IO.fromOption(metadata.data)(
+        new RuntimeException(metadata.errors.map(_.message).headOption.getOrElse("Unable to add or update bulk file metadata"))
+      )
     } yield data.addOrUpdateBulkFileMetadata
 
   def getConsignmentFilesMetadata(consignmentId: UUID, clientSecret: String, databaseMetadataHeaders: List[String]): IO[Option[gcfm.Data]] = {

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -3,9 +3,7 @@ package uk.gov.nationalarchives.draftmetadatavalidator
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.syntax.semigroup._
-import ValidationErrors._
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
-import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
+import com.amazonaws.services.lambda.runtime.Context
 import graphql.codegen.AddOrUpdateBulkFileMetadata.addOrUpdateBulkFileMetadata.AddOrUpdateBulkFileMetadata
 import graphql.codegen.AddOrUpdateBulkFileMetadata.{addOrUpdateBulkFileMetadata => afm}
 import graphql.codegen.GetConsignmentFilesMetadata.{getConsignmentFilesMetadata => gcfm}
@@ -25,6 +23,7 @@ import uk.gov.nationalarchives.aws.utils.s3.S3Clients._
 import uk.gov.nationalarchives.aws.utils.s3.S3Utils
 import uk.gov.nationalarchives.draftmetadatavalidator.ApplicationConfig._
 import uk.gov.nationalarchives.draftmetadatavalidator.Lambda.{ValidationExecutionError, ValidationParameters, getErrorFilePath, getFilePath}
+import uk.gov.nationalarchives.draftmetadatavalidator.ValidationErrors._
 import uk.gov.nationalarchives.draftmetadatavalidator.utils.MetadataUtils
 import uk.gov.nationalarchives.tdr.GraphQLClient
 import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeployment}
@@ -42,7 +41,7 @@ import java.util.{Properties, UUID}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.io.Source
 
-class Lambda extends RequestHandler[java.util.Map[String, Object], APIGatewayProxyResponseEvent] {
+class Lambda {
 
   implicit val backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
   implicit val keycloakDeployment: TdrKeycloakDeployment = TdrKeycloakDeployment(authUrl, "tdr", timeToLiveSecs)
@@ -58,7 +57,7 @@ class Lambda extends RequestHandler[java.util.Map[String, Object], APIGatewayPro
   private val graphQlApi: GraphQlApi =
     GraphQlApi(keycloakUtils, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, getConsignmentFilesMetadataClient)
 
-  def handleRequest(input: java.util.Map[String, Object], context: Context): APIGatewayProxyResponseEvent = {
+  def handleRequest(input: java.util.Map[String, Object], context: Context): Unit = {
     val consignmentId = extractConsignmentId(input)
     val schemaToValidate: Set[JsonSchemaDefinition] = Set(BASE_SCHEMA, CLOSURE_SCHEMA_CLOSED, CLOSURE_SCHEMA_OPEN)
     val validationParameters: ValidationParameters = ValidationParameters(
@@ -70,7 +69,7 @@ class Lambda extends RequestHandler[java.util.Map[String, Object], APIGatewayPro
       requiredSchema = Some(REQUIRED_SCHEMA)
     )
 
-    val requestHandler: IO[APIGatewayProxyResponseEvent] = for {
+    val resultIO = for {
       fileIdData <- graphQlApi.getConsignmentFilesMetadata(
         consignmentId = UUID.fromString(consignmentId),
         clientSecret = getClientSecret(clientSecretPath, endpoint),
@@ -84,21 +83,9 @@ class Lambda extends RequestHandler[java.util.Map[String, Object], APIGatewayPro
       _ <- writeErrorFileDataToFile(validationParameters, errorFileData)
       _ <- if (errorFileData.validationErrors.isEmpty) persistMetadata(validationParameters, clientToPersistenceId) else IO.unit
       _ <- updateStatus(errorFileData, validationParameters)
-    } yield {
-      val response = new APIGatewayProxyResponseEvent()
-      response.setStatusCode(200)
-      response
-    }
+    } yield ()
 
-    requestHandler
-      .handleErrorWith(error => {
-        logger.error(s"Unexpected validation problem:${error.getMessage}")
-        val unexpectedFailureResponse = new APIGatewayProxyResponseEvent()
-        unexpectedFailureResponse.setStatusCode(500)
-        unexpectedFailureResponse.withBody(s"Unexpected validation problem:${error.getMessage}")
-        IO(unexpectedFailureResponse)
-      })
-      .unsafeRunSync()(cats.effect.unsafe.implicits.global)
+    resultIO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 
   private def doValidation(validationParameters: ValidationParameters, clientIdToPersistenceId: Map[String, UUID]): IO[ErrorFileData] = {

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/GraphQlApiSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/GraphQlApiSpec.scala
@@ -16,6 +16,8 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sangria.ast.Document
 import sttp.client3.{HttpURLConnectionBackend, Identity, SttpBackend}
+import uk.gov.nationalarchives.tdr.GraphQLClient.Extensions
+import uk.gov.nationalarchives.tdr.error.GraphQlError
 import uk.gov.nationalarchives.tdr.keycloak.{KeycloakUtils, TdrKeycloakDeployment}
 import uk.gov.nationalarchives.tdr.{GraphQLClient, GraphQlResponse}
 
@@ -45,19 +47,20 @@ class GraphQlApiSpec extends AnyFlatSpec with MockitoSugar with Matchers with Ei
 
   "getCustomMetadata" should "throw an exception when no custom metadata are found" in {
     val api = new GraphQlApi(keycloak, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, consignmentFilesMetadataClient)
+    val graphQlError = GraphQLClient.Error("Unable to get custom metadata", Nil, Nil, Some(Extensions(Some("NOT_AUTHORISED"))))
 
     doAnswer(() => Future(new BearerAccessToken("token")))
       .when(keycloak)
       .serviceAccountToken[Identity](any[String], any[String])(any[SttpBackend[Identity, Any]], any[ClassTag[Identity[_]]], any[TdrKeycloakDeployment])
 
-    doAnswer(() => Future(GraphQlResponse[cm.Data](None, Nil)))
+    doAnswer(() => Future(GraphQlResponse[cm.Data](None, List(GraphQlError(graphQlError)))))
       .when(customMetadataClient)
       .getResult[Identity](any[BearerAccessToken], any[Document], any[Option[cm.Variables]])(any[SttpBackend[Identity, Any]], any[ClassTag[Identity[_]]])
 
     val exception = intercept[RuntimeException] {
       api.getCustomMetadata(consignmentId, "secret").unsafeRunSync()
     }
-    exception.getMessage should equal(s"No custom metadata definitions found")
+    exception.getMessage should equal(s"Unable to get custom metadata")
   }
 
   "getCustomMetadata" should "return the custom metadata" in {
@@ -78,12 +81,13 @@ class GraphQlApiSpec extends AnyFlatSpec with MockitoSugar with Matchers with Ei
 
   "updateConsignmentStatus" should "throw an exception when the api fails to update the consignment status" in {
     val api = new GraphQlApi(keycloak, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, consignmentFilesMetadataClient)
+    val graphQlError = GraphQLClient.Error("Unable to update consignment status", Nil, Nil, Some(Extensions(Some("NOT_AUTHORISED"))))
 
     doAnswer(() => Future(new BearerAccessToken("token")))
       .when(keycloak)
       .serviceAccountToken[Identity](any[String], any[String])(any[SttpBackend[Identity, Any]], any[ClassTag[Identity[_]]], any[TdrKeycloakDeployment])
 
-    doAnswer(() => Future(GraphQlResponse[ucs.Data](None, Nil)))
+    doAnswer(() => Future(GraphQlResponse[ucs.Data](None, List(GraphQlError(graphQlError)))))
       .when(updateConsignmentStatusClient)
       .getResult[Identity](any[BearerAccessToken], any[Document], any[Option[ucs.Variables]])(any[SttpBackend[Identity, Any]], any[ClassTag[Identity[_]]])
 
@@ -113,12 +117,13 @@ class GraphQlApiSpec extends AnyFlatSpec with MockitoSugar with Matchers with Ei
 
   "addOrUpdateBulkFileMetadata" should "throw an exception when the api fails to add or update the file metadata" in {
     val api = new GraphQlApi(keycloak, customMetadataClient, updateConsignmentStatusClient, addOrUpdateBulkFileMetadataClient, consignmentFilesMetadataClient)
+    val graphQlError = GraphQLClient.Error("Unable to add or update bulk file metadata", Nil, Nil, Some(Extensions(Some("NOT_AUTHORISED"))))
 
     doAnswer(() => Future(new BearerAccessToken("token")))
       .when(keycloak)
       .serviceAccountToken[Identity](any[String], any[String])(any[SttpBackend[Identity, Any]], any[ClassTag[Identity[_]]], any[TdrKeycloakDeployment])
 
-    doAnswer(() => Future(GraphQlResponse[ucs.Data](None, Nil)))
+    doAnswer(() => Future(GraphQlResponse[ucs.Data](None, List(GraphQlError(graphQlError)))))
       .when(addOrUpdateBulkFileMetadataClient)
       .getResult[Identity](any[BearerAccessToken], any[Document], any[Option[afm.Variables]])(any[SttpBackend[Identity, Any]], any[ClassTag[Identity[_]]])
 

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -197,8 +197,7 @@ class LambdaSpec extends ExternalServicesSpec {
   private def checkFileError(errorFile: String) = {
     mockS3ErrorFilePutResponse()
     val input = Map("consignmentId" -> consignmentId).asJava
-    val response = new Lambda().handleRequest(input, mockContext)
-//    response.getStatusCode should equal(200)
+    new Lambda().handleRequest(input, mockContext)
 
     val s3Interactions: Iterable[ServeEvent] = wiremockS3.getAllServeEvents.asScala.filter(serveEvent => serveEvent.getRequest.getMethod == RequestMethod.PUT).toList
     s3Interactions.size shouldBe 1

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -1,18 +1,20 @@
 package uk.gov.nationalarchives.draftmetadatavalidator
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.github.tomakehurst.wiremock.client.WireMock.{aResponse, get, put, urlEqualTo}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.http.RequestMethod
 import com.github.tomakehurst.wiremock.stubbing.{ServeEvent, StubMapping}
-import graphql.codegen.UpdateConsignmentStatus.{updateConsignmentStatus => ucs}
 import graphql.codegen.AddOrUpdateBulkFileMetadata.{addOrUpdateBulkFileMetadata => afm}
+import graphql.codegen.UpdateConsignmentStatus.{updateConsignmentStatus => ucs}
 import graphql.codegen.types.{AddOrUpdateBulkFileMetadataInput, AddOrUpdateFileMetadata, AddOrUpdateMetadata, ConsignmentStatusInput}
 import io.circe.generic.auto._
 import io.circe.parser.decode
 import org.mockito.MockitoSugar.mock
-import org.scalatest.matchers.must.Matchers.{be, convertToAnyMustWrapper}
+import org.scalatest.matchers.must.Matchers.{be, convertToAnyMustWrapper, include}
 import org.scalatest.matchers.should.Matchers.{convertToAnyShouldWrapper, equal}
+import sttp.model.StatusCode
 import uk.gov.nationalarchives.draftmetadatavalidator.TestUtils.testFileIdMetadata
+import uk.gov.nationalarchives.tdr.error.HttpException
 
 import java.nio.file.{Files, Paths}
 import java.text.SimpleDateFormat
@@ -52,7 +54,7 @@ class LambdaSpec extends ExternalServicesSpec {
     mockS3ErrorFilePutResponse()
     val input = Map("consignmentId" -> consignmentId).asJava
     val response = new Lambda().handleRequest(input, mockContext)
-    response.getStatusCode should equal(200)
+//    response.getStatusCode should equal(200)
 
     val s3Interactions: Iterable[ServeEvent] = wiremockS3.getAllServeEvents.asScala.filter(serveEvent => serveEvent.getRequest.getMethod == RequestMethod.PUT).toList
     s3Interactions.size shouldBe 1
@@ -80,6 +82,33 @@ class LambdaSpec extends ExternalServicesSpec {
 
     updateConsignmentStatusInput.statusType must be("DraftMetadata")
     updateConsignmentStatusInput.statusValue must be(Some("Completed"))
+  }
+
+  "handleRequest" should "return 500 response and throw an error message when a call to the api fails" in {
+    authOkJson()
+    val fileIdMetadata = testFileIdMetadata(Seq("test/test1.txt", "test/test2.txt", "test/test3.txt"))
+    graphqlOkJson(testFileIdMetadata = fileIdMetadata)
+    mockS3GetResponse("sample.csv")
+    mockS3ErrorFilePutResponse()
+
+    wiremockGraphqlServer.stubFor(
+      post(urlEqualTo(graphQlPath))
+        .withRequestBody(containing("addOrUpdateBulkFileMetadata"))
+        .willReturn(serverError().withBody("Failed to persist metadata"))
+    )
+
+    val input = Map("consignmentId" -> consignmentId).asJava
+    val exception = intercept[HttpException] {
+      new Lambda().handleRequest(input, mockContext)
+    }
+
+    val s3Interactions: Iterable[ServeEvent] = wiremockS3.getAllServeEvents.asScala
+      .filter(serveEvent => serveEvent.getRequest.getMethod == RequestMethod.PUT)
+      .toList
+    s3Interactions.size shouldBe 1
+
+    exception.code should equal(StatusCode(500))
+    exception.getMessage should include("Failed to persist metadata")
   }
 
   "handleRequest" should "download the draft metadata csv file, check for schema errors and save error file with errors to s3" in {
@@ -170,7 +199,7 @@ class LambdaSpec extends ExternalServicesSpec {
     mockS3ErrorFilePutResponse()
     val input = Map("consignmentId" -> consignmentId).asJava
     val response = new Lambda().handleRequest(input, mockContext)
-    response.getStatusCode should equal(200)
+//    response.getStatusCode should equal(200)
 
     val s3Interactions: Iterable[ServeEvent] = wiremockS3.getAllServeEvents.asScala.filter(serveEvent => serveEvent.getRequest.getMethod == RequestMethod.PUT).toList
     s3Interactions.size shouldBe 1

--- a/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
+++ b/src/test/scala/uk/gov/nationalarchives/draftmetadatavalidator/LambdaSpec.scala
@@ -53,8 +53,7 @@ class LambdaSpec extends ExternalServicesSpec {
     mockS3GetResponse("sample.csv")
     mockS3ErrorFilePutResponse()
     val input = Map("consignmentId" -> consignmentId).asJava
-    val response = new Lambda().handleRequest(input, mockContext)
-//    response.getStatusCode should equal(200)
+    new Lambda().handleRequest(input, mockContext)
 
     val s3Interactions: Iterable[ServeEvent] = wiremockS3.getAllServeEvents.asScala.filter(serveEvent => serveEvent.getRequest.getMethod == RequestMethod.PUT).toList
     s3Interactions.size shouldBe 1


### PR DESCRIPTION
The lambda is currently called in a step function but it is returning an APIGateway response so the errors are appended to the response body instead of the lambda just failing.

- Propogate errors so the lambda fails if an exception occurs
- Graphql queries return the actual error instead of custom exception