### PR TITLE
Logging `consignmentId` when Lambda is triggered

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -85,6 +85,7 @@ class Lambda {
       _ <- updateStatus(errorFileData, validationParameters)
     } yield ()
 
+    logger.info(s"Metadata validation was run for $consignmentId")
     resultIO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
   }
 


### PR DESCRIPTION
Small change to log the consignmentId whenever the lambda is triggered. We already log error messages. 