### PR TITLE
Add slf4j-simple dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,6 +21,7 @@ lazy val root = (project in file("."))
       authUtils,
       s3Utils,
       log4catsSlf4j,
+      slf4jSimple,
       circeGenericExtras,
       circeGeneric,
       circeCore,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -20,6 +20,7 @@ object Dependencies {
   lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % "0.1.231"
   lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.26.27"
   lazy val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % log4CatsVersion
+  lazy val slf4jSimple = "org.slf4j" % "slf4j-simple" % "2.0.16"
   lazy val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion
   lazy val mockitoScalaTest = "org.mockito" %% "mockito-scala-scalatest" % mockitoScalaVersion
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -72,6 +72,7 @@ class Lambda {
     )
 
     val resultIO = for {
+      _ <- logger.info(s"Metadata validation was run for $consignmentId")
       fileIdData <- graphQlApi.getConsignmentFilesMetadata(
         consignmentId = UUID.fromString(consignmentId),
         clientSecret = getClientSecret(clientSecretPath, endpoint),
@@ -87,7 +88,6 @@ class Lambda {
       _ <- updateStatus(errorFileData, validationParameters)
     } yield ()
 
-    logger.info(s"Metadata validation was run for $consignmentId")
     resultIO.unsafeRunSync()(cats.effect.unsafe.implicits.global)
     Map[String, Object](
       "consignmentId" -> consignmentId,


### PR DESCRIPTION
This should hopefully fix logs not showing up in Cloudwatch. However it's not much of an issue if it doesn't since all message are now propagated to the step function anyway and errors that occur outside the lambda already show up [example](https://229554778675-xtzq76ks.eu-west-2.console.aws.amazon.com/cloudwatch/home?region=eu-west-2#logsV2:log-groups/log-group/$252Faws$252Flambda$252Ftdr-draft-metadata-validator-intg/log-events/2025$252F02$252F06$252F$255B$2524LATEST$255D160e5315f11940618018749552b3d00e)