### PR TITLE
TDRD-807: metadata write batched

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/ApplicationConfig.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/ApplicationConfig.scala
@@ -19,4 +19,6 @@ object ApplicationConfig {
   val errorFileName: String = configFactory.getString("draftMetadata.errorFileName")
   val timeToLiveSecs: Int = 60
   val graphqlApiRequestTimeOut: FiniteDuration = 180.seconds
+  val batchSizeForMetadataDatabaseWrites: Int = configFactory.getInt("database.write.batchSizeForMetadata")
+  val maxConcurrencyForMetadataDatabaseWrites: Int = configFactory.getInt("database.write.maxConcurrencyForMetadata")
 }

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -338,10 +338,15 @@ class Lambda {
     } yield result
   }
 
-  private def writeMetadataToDatabase(consignmentId: UUID, clientSecret: String, metadata: List[AddOrUpdateFileMetadata] ): IO[List[AddOrUpdateBulkFileMetadata]] = {
-    metadata.grouped(batchSizeForMetadataDatabaseWrites).map { mdGroup =>
-      graphQlApi.addOrUpdateBulkFileMetadata(consignmentId, clientSecret, mdGroup)
-    }.toList.parSequence.map(_.flatten)
+  private def writeMetadataToDatabase(consignmentId: UUID, clientSecret: String, metadata: List[AddOrUpdateFileMetadata]): IO[List[AddOrUpdateBulkFileMetadata]] = {
+    metadata
+      .grouped(batchSizeForMetadataDatabaseWrites)
+      .map { mdGroup =>
+        graphQlApi.addOrUpdateBulkFileMetadata(consignmentId, clientSecret, mdGroup)
+      }
+      .toList
+      .parSequence
+      .map(_.flatten)
   }
 
   private def writeErrorFileDataToFile(validationParameters: ValidationParameters, errorFileData: ErrorFileData) = {

--- a/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/draftmetadatavalidator/Lambda.scala
@@ -63,8 +63,6 @@ class Lambda {
   private val updateMetadataSchemaLibraryVersionClient = new GraphQLClient[ucslv.Data, ucslv.Variables](apiUrl)
   private val getFilesWithUniqueAssetIdKey = new GraphQLClient[uaik.Data, uaik.Variables](apiUrl)
 
-  private val batchSizeForMetadataDatabaseWrites = 1000
-
   private val graphQlApi: GraphQlApi = GraphQlApi(
     keycloakUtils,
     customMetadataClient,
@@ -341,9 +339,7 @@ class Lambda {
   }
 
   private def writeMetadataToDatabase(consignmentId: UUID, clientSecret: String, metadata: List[AddOrUpdateFileMetadata]): IO[List[AddOrUpdateBulkFileMetadata]] = {
-    val maxConcurrency = 10
-
-    Semaphore[IO](maxConcurrency).flatMap { semaphore =>
+    Semaphore[IO](maxConcurrencyForMetadataDatabaseWrites).flatMap { semaphore =>
       metadata
         .grouped(batchSizeForMetadataDatabaseWrites)
         .toList

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -19,3 +19,7 @@ draftMetadata {
   errorFileName = "draft-metadata-errors.json"
 }
 root.directory = "./src/test/resources/testfiles/running-files"
+database.write {
+  batchSizeForMetadata = 1000
+  maxConcurrencyForMetadata = 10
+}


### PR DESCRIPTION
Database write of large metadata file (e.g. 10k rows) failing in one go; instead make the write in batches (set at 1,000 here)