### PR TITLE
Fix unit tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,4 +47,5 @@ lazy val root = (project in file("."))
 
 (Test / fork) := true
 (Test / javaOptions) += s"-Dconfig.file=${sourceDirectory.value}/test/resources/application.conf"
-(Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test")
+(Test / envVars) := Map("AWS_ACCESS_KEY_ID" -> "test", "AWS_SECRET_ACCESS_KEY" -> "test",
+  "AWS_REQUEST_CHECKSUM_CALCULATION" -> "when_required", "AWS_RESPONSE_CHECKSUM_CALCULATION" -> "when_required")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,22 +3,22 @@ import sbt.*
 object Dependencies {
 
   private val log4CatsVersion = "2.7.0"
-  private val mockitoScalaVersion = "1.17.37"
+  private val mockitoScalaVersion = "1.17.45"
   private val circeVersion = "0.14.13"
-  val metadataSchemaVersion = "0.0.59"
+  val metadataSchemaVersion = "0.0.60"
 
   lazy val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "2.0.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
   lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.139" exclude ("uk.gov.nationalarchives", "da-metadata-schema")
   lazy val metadataSchema = "uk.gov.nationalarchives" %% "da-metadata-schema" % metadataSchemaVersion
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.411"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.224"
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.240"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.225"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.242"
   lazy val typeSafeConfig = "com.typesafe" % "config" % "1.4.3"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.2.3"
   lazy val awsLambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.15.0"
-  lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % "0.1.242"
-  lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.26.27"
+  lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % "0.1.268"
+  lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.31.48"
   lazy val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % log4CatsVersion
   lazy val slf4jSimple = "org.slf4j" % "slf4j-simple" % "2.0.17"
   lazy val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion

--- a/src/test/resources/json/error-file-foi-code-period-mismatch.json
+++ b/src/test/resources/json/error-file-foi-code-period-mismatch.json
@@ -10,13 +10,13 @@
           "validationProcess" : "ROW_VALIDATION",
           "property" : "foi_exemption_code",
           "errorKey" : "closureCodeAndPeriodMismatch",
-          "message" : "Must have the same number of closure periods as foi exemption codes"
+          "message" : "ROW_VALIDATION.closureCodeAndPeriodMismatch"
         },
         {
           "validationProcess" : "ROW_VALIDATION",
           "property" : "closure_period",
           "errorKey" : "closureCodeAndPeriodMismatch",
-          "message" : "Must have the same number of closure periods as foi exemption codes"
+          "message" : "ROW_VALIDATION.closureCodeAndPeriodMismatch"
         }
       ],
       "data" : [

--- a/src/test/resources/json/error-file.json
+++ b/src/test/resources/json/error-file.json
@@ -10,7 +10,7 @@
           "validationProcess" : "SCHEMA_BASE",
           "property" : "foi exemption code",
           "errorKey" : "enum",
-          "message" : "Must be a semi-colon separated list of valid FOI codes, (eg. 31;33). Please see the guidance for more detail on valid codes"
+          "message" : "Must be a valid FOI exemption code, or a semi-colon separated list of valid FOI exemption codes, eg. 31;33"
         },
         {
           "validationProcess" : "SCHEMA_BASE",


### PR DESCRIPTION
AWS S3 recently introduced addiional checksum functionality

To prevent checksum appearing in the raw output of unit tests add environmental variables