### PR TITLE
Update for group all in scala-steward-dependencies (#825)

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   pre-deploy-checks:
     permissions: { contents: write, id-token: write }
-    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@27efbc03aaaa9696eea85ab7a9363d6f92733471 # v0.0.34
+    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@8f8b90556173b43554c22d6b5f192fe9f26ad8ab # v0.0.36
     with:
       repo-name: tdr-draft-metadata-validator
       lambda-name: draft-metadata-checks

--- a/.github/workflows/build-persistence.yml
+++ b/.github/workflows/build-persistence.yml
@@ -20,7 +20,7 @@ permissions: {}
 jobs:
   pre-deploy-persistence:
     permissions: { contents: write, id-token: write }
-    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@27efbc03aaaa9696eea85ab7a9363d6f92733471 # v0.0.34
+    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_build.yml@8f8b90556173b43554c22d6b5f192fe9f26ad8ab # v0.0.36
     with:
       repo-name: tdr-draft-metadata-validator
       lambda-name: draft-metadata-persistence

--- a/.github/workflows/deploy-lambda.yml
+++ b/.github/workflows/deploy-lambda.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_deploy.yml@27efbc03aaaa9696eea85ab7a9363d6f92733471 # v0.0.34
+    uses: nationalarchives/tdr-github-actions/.github/workflows/lambda_deploy.yml@8f8b90556173b43554c22d6b5f192fe9f26ad8ab # v0.0.36
     with:
       lambda-name: ${{ github.event.inputs.lambda-name }}
       deployment-package: ${{ github.event.inputs.deployment-package }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@27efbc03aaaa9696eea85ab7a9363d6f92733471 # v0.0.34
+    uses: nationalarchives/tdr-github-actions/.github/workflows/tdr_test.yml@8f8b90556173b43554c22d6b5f192fe9f26ad8ab # v0.0.36
     with:
       repo-name: tdr-draft-metadata-validator
       test-command: |

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.10.7
+version = 3.11.0
 preset = default
 runner.dialect = scala213
 maxColumn = 180

--- a/lambdas/tdr-draft-metadata-checks/src/test/scala/uk/gov/nationalarchives/tdr/draftmetadatachecks/LambdaSpec.scala
+++ b/lambdas/tdr-draft-metadata-checks/src/test/scala/uk/gov/nationalarchives/tdr/draftmetadatachecks/LambdaSpec.scala
@@ -195,8 +195,8 @@ class LambdaSpec extends ExternalServicesSpec {
     val filePath = getClass.getResource(s"/$fileName").getFile
     val bytes = Files.readAllBytes(Paths.get(filePath))
     wiremockS3.stubFor(
-      get(urlEqualTo(s"/$consignmentId/sample.csv"))
-        .willReturn(aResponse().withStatus(200).withBody(bytes))
+      get(urlPathEqualTo(s"/$consignmentId/sample.csv"))
+        .willReturn(aResponse().withStatus(200).withHeader("Content-Length", bytes.length.toString).withBody(bytes))
     )
   }
 

--- a/lambdas/tdr-draft-metadata-persistence/src/test/scala/uk/gov/nationalarchives/tdr/draftmetadatapersistence/LambdaSpec.scala
+++ b/lambdas/tdr-draft-metadata-persistence/src/test/scala/uk/gov/nationalarchives/tdr/draftmetadatapersistence/LambdaSpec.scala
@@ -132,8 +132,8 @@ class LambdaSpec extends ExternalServicesSpec {
     val filePath = getClass.getResource(s"/$fileName").getFile
     val bytes = Files.readAllBytes(Paths.get(filePath))
     wiremockS3.stubFor(
-      get(urlEqualTo(s"/$consignmentId/sample.csv"))
-        .willReturn(aResponse().withStatus(200).withBody(bytes))
+      get(urlPathEqualTo(s"/$consignmentId/sample.csv"))
+        .willReturn(aResponse().withStatus(200).withHeader("Content-Length", bytes.length.toString).withBody(bytes))
     )
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,22 +3,22 @@ import sbt.*
 object Dependencies {
 
   private val log4CatsVersion = "2.8.0"
-  private val mockitoScalaVersion = "2.1.0"
+  private val mockitoScalaVersion = "2.2.1"
   private val circeVersion = "0.14.15"
   val metadataSchemaVersion = "0.0.129"
 
   lazy val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "2.0.0"
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.19"
-  lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.204" exclude ("uk.gov.nationalarchives", "da-metadata-schema")
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.20"
+  lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.216" exclude ("uk.gov.nationalarchives", "da-metadata-schema")
   lazy val metadataSchema = "uk.gov.nationalarchives" %% "da-metadata-schema" % metadataSchemaVersion
-  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.460"
-  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.282"
-  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.277"
+  lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.467"
+  lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.291"
+  lazy val authUtils = "uk.gov.nationalarchives" %% "tdr-auth-utils" % "0.0.283"
   lazy val typeSafeConfig = "com.typesafe" % "config" % "1.4.6"
   lazy val awsLambda = "com.amazonaws" % "aws-lambda-java-core" % "1.4.0"
   lazy val awsLambdaJavaEvents = "com.amazonaws" % "aws-lambda-java-events" % "3.16.1"
-  lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % "0.1.319"
-  lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.42.13"
+  lazy val s3Utils = "uk.gov.nationalarchives" %% "s3-utils" % "0.1.325"
+  lazy val awsSsm = "software.amazon.awssdk" % "ssm" % "2.42.34"
   lazy val log4catsSlf4j = "org.typelevel" %% "log4cats-slf4j" % log4CatsVersion
   lazy val slf4jSimple = "org.slf4j" % "slf4j-simple" % "2.0.17"
   lazy val mockitoScala = "org.mockito" %% "mockito-scala" % mockitoScalaVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
 
   lazy val scalaCsv = "com.github.tototoshi" %% "scala-csv" % "2.0.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.20"
-  lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.216" exclude ("uk.gov.nationalarchives", "da-metadata-schema")
+  lazy val metadataValidation = "uk.gov.nationalarchives" %% "tdr-metadata-validation" % "0.0.220" exclude ("uk.gov.nationalarchives", "da-metadata-schema")
   lazy val metadataSchema = "uk.gov.nationalarchives" %% "da-metadata-schema" % metadataSchemaVersion
   lazy val generatedGraphql = "uk.gov.nationalarchives" %% "tdr-generated-graphql" % "0.0.467"
   lazy val graphqlClient = "uk.gov.nationalarchives" %% "tdr-graphql-client" % "0.0.291"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.6
+sbt.version=1.12.9

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
 addSbtPlugin("com.eed3si9n" %% "sbt-assembly" % "2.3.1")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.0")


### PR DESCRIPTION
* Update mockito-scala to 2.2.1 in scala-steward-dependencies

* Update sbt to 1.12.9 in scala-steward-dependencies

* Update sbt-scalafmt to 2.6.0 in scala-steward-dependencies

* Update scalafmt-core to 3.11.0 in scala-steward-dependencies

* Update scalatest to 3.2.20 in scala-steward-dependencies

* Update ssm to 2.42.34 in scala-steward-dependencies

* Update s3-utils to 0.1.325 in scala-steward-dependencies

* Update tdr-auth-utils to 0.0.283 in scala-steward-dependencies

* Update tdr-generated-graphql to 0.0.467 in scala-steward-dependencies

* Update tdr-graphql-client to 0.0.291 in scala-steward-dependencies

* Update tdr-metadata-validation to 0.0.216 in scala-steward-dependencies

* version update for 2006-12-31-closure-start-date (#827)

* version update for 2006-12-31-closure-start-date

* test 2006-12-31

* fix tests

---------